### PR TITLE
S05: slow down certain event-spawned enemies on EASY

### DIFF
--- a/macros/unit-utils.cfg
+++ b/macros/unit-utils.cfg
@@ -58,3 +58,13 @@
         passable=yes
     [/unit]
 #enddef
+
+#define SLOWED_IF_EASY
+    [+unit]
+        [+status]
+#ifdef EASY
+            slowed=yes
+#endif
+        [/status]
+    [/unit]
+#enddef

--- a/scenarios/05_Across_The_Dark_Hills.cfg
+++ b/scenarios/05_Across_The_Dark_Hills.cfg
@@ -201,16 +201,16 @@
 #endif
             side=1
         [/filter]
-        {NAMED_GENERIC_UNIT 4 (Orcish Grunt) 58 7 (Orc 1) ( _ "Orc Ambusher")}
-        {NAMED_GENERIC_UNIT 4 (Troll Whelp) 54 8 (Troll 1) ( _ "Troll Ambusher")}
-        {NAMED_GENERIC_UNIT 4 (Young Ogre) 55 11 (Ogre 1) ( _ "Ogre Ambusher")}
+        {NAMED_GENERIC_UNIT 4 (Orcish Grunt) 58 7 (Orc 1) ( _ "Orc Ambusher")} {SLOWED_IF_EASY}
+        {NAMED_GENERIC_UNIT 4 (Troll Whelp) 54 8 (Troll 1) ( _ "Troll Ambusher")} {SLOWED_IF_EASY}
+        {NAMED_GENERIC_UNIT 4 (Young Ogre) 55 11 (Ogre 1) ( _ "Ogre Ambusher")} {SLOWED_IF_EASY}
 #ifdef EASY
         {NAMED_GENERIC_UNIT 4 (Troll Whelp) 53 10 (Troll 2) ( _ "Troll Ambusher")}
 #else
         {NAMED_GENERIC_UNIT 4 (Troll Rocklobber) 53 10 (Troll 2) ( _ "Troll Ambusher")}
 #endif
-        {NAMED_GENERIC_UNIT 4 (Ogre) 55 11 (Ogre 2) ( _ "Ogre Ambusher")}
-        {NAMED_GENERIC_UNIT 4 (Troll Whelp) 57 14 (Troll 3) ( _ "Troll Ambusher")}
+        {NAMED_GENERIC_UNIT 4 (Ogre) 55 11 (Ogre 2) ( _ "Ogre Ambusher")} {SLOWED_IF_EASY}
+        {NAMED_GENERIC_UNIT 4 (Troll Whelp) 57 14 (Troll 3) ( _ "Troll Ambusher")} {SLOWED_IF_EASY}
         #the "leaders"
         {NAMED_GENERIC_UNIT 4 (Troll) 50 12 (Troll Captain 1) ( _ "Troll Captain")}
         {GUARDIAN}
@@ -351,10 +351,10 @@
         {NAMED_GENERIC_UNIT 6 (Thief) 27 11 Jacla ( _ "Jacla")}{MAKE_MALE}
         {NAMED_GENERIC_UNIT 6 (Footpad) 28 10 Lirydda ( _ "Lirydda")}{MAKE_FEMALE}
         {NAMED_GENERIC_UNIT 6 (Outlaw) 29 10 Addryn ( _ "Addryn")}{MAKE_MALE}
-        {NAMED_GENERIC_UNIT 3 (Minotaur Savage) 24 13 (Granmaruk_Boldbane) ( _ "Granmaruk Boldbane")}
-        {NAMED_GENERIC_UNIT 3 (Minotaur Slayer) 23 13 (Tesken_Fearlesshorn) ( _ "Tesken Fearlesshorn")}
-        {NAMED_GENERIC_UNIT 3 (Minotaur Gore) 33 13 (Foosfaruk_Ironslayer) ( _ "Foosfaruk Ironslayer")}
-        {NAMED_GENERIC_UNIT 3 (Minotaur Ancient Behemoth) 29 15 (Gran) ( _ "Gran")}
+        {NAMED_GENERIC_UNIT 3 (Minotaur Savage) 24 13 (Granmaruk_Boldbane) ( _ "Granmaruk Boldbane")} {SLOWED_IF_EASY}
+        {NAMED_GENERIC_UNIT 3 (Minotaur Slayer) 23 13 (Tesken_Fearlesshorn) ( _ "Tesken Fearlesshorn")} {SLOWED_IF_EASY}
+        {NAMED_GENERIC_UNIT 3 (Minotaur Gore) 33 13 (Foosfaruk_Ironslayer) ( _ "Foosfaruk Ironslayer")} {SLOWED_IF_EASY}
+        {NAMED_GENERIC_UNIT 3 (Minotaur Ancient Behemoth) 29 15 (Gran) ( _ "Gran")} {SLOWED_IF_EASY}
         [unit]
             type=Minotaur Elder
             id=Minotaur_Lord


### PR DESCRIPTION
I think that doing this would do a better job improving the fix for #5, although maybe there should be an "else" branch for the ifdef in the `{SLOWED_IF_EASY}` macro, just so that it isn't empty on higher difficulties?
