### PR TITLE
Update 06_The_Courtyard.cfg to refresh the player units' moves

### DIFF
--- a/scenarios/06_The_Courtyard.cfg
+++ b/scenarios/06_The_Courtyard.cfg
@@ -40,6 +40,15 @@
             {TELEPORT_UNIT role=healer 17 9}
             #                [/else]
             #            [/if]
+#ifdef EASY
+            [heal_unit]
+                [filter]
+                    side=1
+                [/filter]
+                moves=full
+                restore_attacks=yes
+            [/heal_unit]
+#endif
             {REDRAW}
             {NAMED_LOYAL_UNIT 3 (White Mage) 1 10 Durrcyn ( _ "Durrcyn")}
             {MOVE_UNIT id=Durrcyn 13 9}


### PR DESCRIPTION
This gives the player time to regroup after getting trapped by the enemies.
(I still died even with this change in place, though, so it might need further work...)
